### PR TITLE
Fixed failing-example to work.

### DIFF
--- a/failing-example/SConstruct
+++ b/failing-example/SConstruct
@@ -1,2 +1,10 @@
-env = Environment()
+# Change to path to your mingw ucrt
+mgw_ucrt_path=r'E:\tools\ucrt-11.2.0'
+
+env = Environment(tools=[])
+env.AppendENVPath('PATH',mgw_ucrt_path)
+env.Append(CPPPATH=mgw_ucrt_path)
+env.Tool('mingw')
 env.Program("hello.c")
+print("PATH:%s"%env['ENV']['PATH'])
+print("CC:%s"%env['CC'])


### PR DESCRIPTION
Changed SConstruct in failing dir to work by 

- specifying path to ucrt tools install
- setting env['ENV']['PATH'] to that as well as env['CPPPATH']. 
- explicitly only initialzing mingw tool after setting PATH